### PR TITLE
PHP8化に伴う微修正

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,7 +44,7 @@ jobs:
           restore-keys: ${{ runner.os }}-php${{ matrix.php-version }}-composer-
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist --ignore-platform-req=php
+        run: composer install --no-interaction --prefer-dist
 
       - name: QA
         run: PHP_CS_FIXER_IGNORE_ENV=1 composer qa

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --ignore-platform-req=php
 
-      - name: Run test suite
-        run: ./vendor/bin/phpunit
+      - name: QA
+        run: composer qa

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,14 +34,14 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --ignore-platform-req=php

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,8 +40,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
+          key: ${{ runner.os }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-php${{ matrix.php-version }}-composer-
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --ignore-platform-req=php

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,4 +47,4 @@ jobs:
         run: composer install --no-interaction --prefer-dist --ignore-platform-req=php
 
       - name: QA
-        run: composer qa
+        run: PHP_CS_FIXER_IGNORE_ENV=1 composer qa

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,6 +2,8 @@ name: Continuous Integration
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /phpunit.xml
 /composer.lock
 .php_cs.cache
+.phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,13 +5,14 @@ $finder = \PhpCsFixer\Finder::create()
     ->in(__DIR__)
 ;
 
-return \PhpCsFixer\Config::create()
+return (new \PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
         'concat_space' => false,
         'phpdoc_summary' => false,
         'yoda_style' => false,
         'return_type_declaration' => ['space_before' => 'one'],
+        'global_namespace_import' => true,
     ])
     ->setFinder($finder)
     ->setUsingCache(false)

--- a/composer.json
+++ b/composer.json
@@ -36,16 +36,19 @@
         ],
         "cs-fix": [
             "php-cs-fixer fix -v"
+        ],
+        "rector": [
+            "rector process --memory-limit=-1"
         ]
     },
     "require": {
         "php": "^8.0",
-        "laminas/laminas-diactoros": "^2.24",
-        "rector/rector": "^0.15.19"
+        "laminas/laminas-diactoros": "^2.24"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^1.0",
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "rector/rector": "^0.15.21"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,16 @@
             "phpunit"
         ],
         "analyse" : [
-            "phpstan analyse -l max --no-progress src"
+            "phpstan analyse -l max --no-progress src --memory-limit=-1"
         ],
         "analyze" : [
             "@analyse"
         ],
         "cs": [
             "php-cs-fixer fix -v --dry-run --diff"
+        ],
+        "cs-fix": [
+            "php-cs-fixer fix -v"
         ]
     },
     "require": {
@@ -43,6 +46,6 @@
     "require-dev": {
         "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^1.0",
-        "friendsofphp/php-cs-fixer": "^2.12"
+        "friendsofphp/php-cs-fixer": "^3.0"
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -6,7 +6,7 @@ use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 
-return static function (RectorConfig $rectorConfig): void {
+return static function (RectorConfig $rectorConfig) : void {
     $rectorConfig->paths([
         __DIR__ . '/src',
         __DIR__ . '/tests',
@@ -16,7 +16,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
 
     // define sets of rules
-        $rectorConfig->sets([
-            LevelSetList::UP_TO_PHP_80
-        ]);
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_80,
+    ]);
 };

--- a/src/RealTemporaryDirectory.php
+++ b/src/RealTemporaryDirectory.php
@@ -4,12 +4,13 @@ namespace Kalibora\RealTemporaryFile;
 
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use RuntimeException;
 use SplFileInfo;
 
 /**
  * @method string getRealPath()
  */
-class RealTemporaryDirectory extends \SplFileInfo
+class RealTemporaryDirectory extends SplFileInfo
 {
     private bool $destructed = false;
 
@@ -21,7 +22,7 @@ class RealTemporaryDirectory extends \SplFileInfo
         $tempfile = tempnam(sys_get_temp_dir(), $prefix);
 
         if ($tempfile === false) {
-            throw new \RuntimeException('Cannot create temp file.');
+            throw new RuntimeException('Cannot create temp file.');
         }
 
         if (file_exists($tempfile)) {
@@ -31,7 +32,7 @@ class RealTemporaryDirectory extends \SplFileInfo
         mkdir($tempfile, $mode = 0777);
 
         if (!is_dir($tempfile)) {
-            throw new \RuntimeException('Cannot create directory. ' . $tempfile);
+            throw new RuntimeException('Cannot create directory. ' . $tempfile);
         }
 
         parent::__construct($tempfile);

--- a/src/RealTemporaryFile.php
+++ b/src/RealTemporaryFile.php
@@ -2,12 +2,13 @@
 
 namespace Kalibora\RealTemporaryFile;
 
+use SplFileObject;
 use Zend\Diactoros\UploadedFile;
 
 /**
  * @method string getRealPath()
  */
-class RealTemporaryFile extends \SplFileObject
+class RealTemporaryFile extends SplFileObject
 {
     public const DEFAULT_PREFIX = 'kalibora_real_tmp_';
 

--- a/tests/RealTemporaryFileTest.php
+++ b/tests/RealTemporaryFileTest.php
@@ -36,7 +36,7 @@ class RealTemporaryFileTest extends TestCase
     {
         $file = new RealTemporaryFile();
 
-        $this->assertRegexp('/^kalibora_real_tmp_.*$/', $file->getFilename());
+        $this->assertMatchesRegularExpression('/^kalibora_real_tmp_.*$/', $file->getFilename());
         $this->assertSame('', $file->getExtension());
     }
 
@@ -44,7 +44,7 @@ class RealTemporaryFileTest extends TestCase
     {
         $file = RealTemporaryFile::createWithExtension('txt');
 
-        $this->assertRegexp('/^kalibora_real_tmp_.*\.txt$/', $file->getFilename());
+        $this->assertMatchesRegularExpression('/^kalibora_real_tmp_.*\.txt$/', $file->getFilename());
         $this->assertSame('txt', $file->getExtension());
     }
 


### PR DESCRIPTION
#3 の微修正

- php-cs-fixer を v3系に
- phpunit9 の deprecation warning を潰す
- CI
  - phpunit  だけでなく他のQA系も実行する
  - master に push したときのみ CI を実行